### PR TITLE
Autofixing errors whenever there is an error generated

### DIFF
--- a/apps/studio/src/lib/editor/engine/error/index.ts
+++ b/apps/studio/src/lib/editor/engine/error/index.ts
@@ -1,6 +1,6 @@
 import type { ProjectsManager } from '@/lib/projects';
 import { type ParsedError, compareErrors } from '@onlook/utility';
-import { makeAutoObservable } from 'mobx';
+import { autorun, makeAutoObservable } from 'mobx';
 import type { EditorEngine } from '..';
 
 export class ErrorManager {
@@ -13,11 +13,21 @@ export class ErrorManager {
         private editorEngine: EditorEngine,
         private projectsManager: ProjectsManager,
     ) {
-        makeAutoObservable(this, {});
+        makeAutoObservable(this);
+
+        autorun(() => {
+            if (this.shouldAutoFixErrors) {
+                this.sendFixError();
+            }
+        });
     }
 
     get errors() {
         return [...this.terminalErrors];
+    }
+
+    get shouldAutoFixErrors() {
+        return this.errors.length > 0 && !this.editorEngine.chat.isWaiting;
     }
 
     async sendFixError() {


### PR DESCRIPTION
## Description

Instead of fixing errors on clicking Fix button, tries to fix the error whenever there is an error generated

## Related Issues

fixes #1617

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Automatically fix errors in `ErrorManager` using `autorun` to trigger `sendFixError()` when errors occur.
> 
>   - **Behavior**:
>     - Automatically fixes errors when they occur using `autorun` in `ErrorManager`.
>     - `shouldAutoFixErrors` checks if errors exist and if the chat is not waiting before triggering `sendFixError()`.
>   - **Functions**:
>     - Adds `autorun` in `ErrorManager` constructor to automatically call `sendFixError()`.
>     - `sendFixError()` now removes errors from map if fixed.
>   - **Misc**:
>     - Removes `makeAutoObservable` options in `ErrorManager` constructor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 04dcb17763925e781062388ea43bbb663e7694c4. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->