### PR TITLE
Add the terminal output to the chat context

### DIFF
--- a/apps/studio/src/lib/editor/engine/index.ts
+++ b/apps/studio/src/lib/editor/engine/index.ts
@@ -350,6 +350,18 @@ export class EditorEngine {
         };
     }
 
+    async getTerminalOutput(): Promise<string | null> {
+        try {
+            if (!this.projectsManager.runner) {
+                return null;
+            }
+            const history = await this.projectsManager.runner.getHistory();
+            return history || null;
+        } catch (error) {
+            console.error('Failed to get terminal output:', error);
+            return null;
+        }
+    }
     canDeleteWindow() {
         return this.canvas.frames.length > 1;
     }

--- a/apps/studio/src/routes/editor/EditPanel/ChatTab/ChatInput.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/ChatTab/ChatInput.tsx
@@ -420,6 +420,33 @@ export const ChatInput = observer(() => {
                             </TooltipContent>
                         </TooltipPortal>
                     </Tooltip>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant={'ghost'}
+                                size={'icon'}
+                                className="w-9 h-9 text-foreground-tertiary group hover:bg-transparent"
+                                onClick={() => {
+                                    editorEngine.chat.context.addTerminalContext();
+                                }}
+                                disabled={disabled}
+                            >
+                                <Icons.Terminal
+                                    className={cn(
+                                        'w-5 h-5',
+                                        disabled
+                                            ? 'text-foreground-tertiary'
+                                            : 'group-hover:text-foreground',
+                                    )}
+                                />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipPortal>
+                            <TooltipContent side="top" sideOffset={5}>
+                                {disabled ? 'Select an element to start' : 'Add terminal output'}
+                            </TooltipContent>
+                        </TooltipPortal>
+                    </Tooltip>
                     <Button
                         variant={'outline'}
                         className="w-fit h-fit py-0.5 px-2.5 text-foreground-tertiary hidden"

--- a/apps/studio/src/routes/editor/EditPanel/ChatTab/ContextPills/helpers.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/ChatTab/ContextPills/helpers.tsx
@@ -35,6 +35,9 @@ export function getContextIcon(context: ChatMessageContext) {
         case MessageContextType.PROJECT:
             icon = Icons.Cube;
             break;
+        case MessageContextType.TERMINAL:
+            icon = Icons.Terminal;
+            break;
         default:
             assertNever(context);
     }

--- a/packages/models/src/chat/message/context.ts
+++ b/packages/models/src/chat/message/context.ts
@@ -4,6 +4,7 @@ export enum MessageContextType {
     IMAGE = 'image',
     ERROR = 'error',
     PROJECT = 'project',
+    TERMINAL = 'terminal',
 }
 
 type BaseMessageContext = {
@@ -38,9 +39,16 @@ export type ProjectMessageContext = BaseMessageContext & {
     path: string;
 };
 
+export type TerminalMessageContext = BaseMessageContext & {
+    type: MessageContextType.TERMINAL;
+    content: string;
+    displayName: string;
+};
+
 export type ChatMessageContext =
     | FileMessageContext
     | HighlightMessageContext
     | ImageMessageContext
     | ErrorMessageContext
-    | ProjectMessageContext;
+    | ProjectMessageContext
+    | TerminalMessageContext;


### PR DESCRIPTION
## Description

Added the terminal message in the chat context

## Related Issues

related #1593

## Screenshot
![Screenshot from 2025-05-11 19-22-54](https://github.com/user-attachments/assets/0155fea4-4aeb-4b77-bd2c-9500128862f3)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add terminal output to chat context, enabling users to include terminal messages in chat interactions.
> 
>   - **Behavior**:
>     - Adds terminal output to chat context in `ChatContext` class in `context.ts`.
>     - Implements `getTerminalContext()` and `addTerminalContext()` in `ChatContext` to manage terminal messages.
>     - Adds `getTerminalOutput()` in `EditorEngine` in `index.ts` to fetch terminal history.
>   - **UI**:
>     - Adds button in `ChatInput.tsx` to trigger terminal output addition to chat context.
>   - **Models**:
>     - Adds `TERMINAL` type to `MessageContextType` in `context.ts`.
>     - Defines `TerminalMessageContext` type in `context.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for b5d9f6214cc64bf13bc67d3588578bcdd9ca2038. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->