### PR TITLE
Fixed the element color refresh to default color when color is deleted from brand panel

### DIFF
--- a/apps/studio/src/lib/editor/engine/style/index.ts
+++ b/apps/studio/src/lib/editor/engine/style/index.ts
@@ -80,6 +80,22 @@ export class StyleManager {
     update(style: string, value: string) {
         const styleObj = { [style]: value };
         const action = this.getUpdateStyleAction(styleObj);
+
+        if (!value) {
+            const updatedTargets = action.targets.map((target) => ({
+                ...target,
+                change: {
+                    ...target.change,
+                    update: {
+                        [style]: {
+                            value: '',
+                            type: StyleChangeType.Value,
+                        },
+                    },
+                },
+            }));
+            action.targets = updatedTargets;
+        }
         this.editorEngine.action.run(action);
         this.updateStyleNoAction(styleObj);
     }

--- a/apps/studio/src/lib/editor/engine/theme/index.ts
+++ b/apps/studio/src/lib/editor/engine/theme/index.ts
@@ -335,6 +335,8 @@ export class ThemeManager {
 
             // Refresh colors after deletion
             this.scanConfig();
+
+            await this.editorEngine.webviews.reloadWebviews();
         } catch (error) {
             console.error('Error deleting color:', error);
         }

--- a/apps/studio/src/lib/editor/engine/theme/index.ts
+++ b/apps/studio/src/lib/editor/engine/theme/index.ts
@@ -378,10 +378,10 @@ export class ThemeManager {
                 });
 
                 // Refresh colors after update
-                this.scanConfig();
+                await this.scanConfig();
 
                 // Force a theme refresh for all frames
-                await this.editorEngine.webviews.reloadWebviews();
+                this.editorEngine.webviews.reloadWebviews();
             }
         } catch (error) {
             console.error('Error updating color:', error);

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
@@ -108,6 +108,21 @@ const ColorInput = observer(
 
         // Update color state when getColor changes
         const [color, setColor] = useState(getColor);
+
+        useEffect(() => {
+            const styles = editorEngine.style.selectedStyle?.styles || {};
+            const currentValue = elementStyle.getValue(styles);
+
+            if (currentValue && !currentValue.startsWith('#')) {
+                const colorExists = editorEngine.theme.getColorByName(currentValue);
+
+                if (!colorExists) {
+                    const defaultColor = Color.from(elementStyle.defaultValue);
+                    sendStyleUpdate(defaultColor);
+                }
+            }
+        }, [editorEngine.theme.colorGroups, editorEngine.theme.colorDefaults]);
+
         useEffect(() => {
             if (!isFocused) {
                 setColor(getColor);


### PR DESCRIPTION

## Description

Fixed element color refresh to it's default value when the color is deleted from brand panel

## Related Issues

fixes #1789

## Testing

Tested by running locally

## Screenshots (if applicable)

[Screencast from 2025-04-27 15-17-23.webm](https://github.com/user-attachments/assets/9c54ab1e-8ca1-4cd1-a45b-dda03fd72246)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes element color reverting to default when deleted from brand panel and ensures UI refresh in `StyleManager`, `ThemeManager`, and `ColorInput`.
> 
>   - **Behavior**:
>     - Fixes element color reverting to default when deleted from brand panel in `StyleManager.update()` in `style/index.ts`.
>     - Ensures UI refreshes after color deletion in `ThemeManager.delete()` in `theme/index.ts`.
>   - **UI**:
>     - Adds effect in `ColorInput` in `ColorInput/index.tsx` to update color state when a color is deleted and not found in theme.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for daf2f8335ca34ed0f1ca4a22d86f9ac51cda00f5. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->