### PR TITLE
fix: style panel not detecting applied text color (shows "None")

### DIFF
--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
@@ -4,7 +4,7 @@ import { invokeMainChannel } from '@/lib/utils';
 import type { ColorItem } from '@/routes/editor/LayersPanel/BrandTab/ColorPanel/ColorPalletGroup';
 import { DEFAULT_COLOR_NAME, MainChannels } from '@onlook/models/constants';
 import { Icons } from '@onlook/ui/icons';
-import { Color, isColorEmpty } from '@onlook/utility';
+import { Color, isColorEmpty, resolveCssVariables } from '@onlook/utility';
 import { observer } from 'mobx-react-lite';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { BrandPopoverPicker } from './ColorBrandPicker';
@@ -98,12 +98,17 @@ const ColorInput = observer(
             }
             const newValue = elementStyle.getValue(editorEngine.style.selectedStyle?.styles);
 
+            const resolvedValue = resolveCssVariables(
+                newValue,
+                editorEngine.style.selectedStyle.styles,
+            );
+
             const color = editorEngine.theme.getColorByName(newValue);
             if (color) {
                 return Color.from(color);
             }
 
-            return Color.from(newValue);
+            return Color.from(resolvedValue);
         }, [editorEngine.style.selectedStyle?.styles, elementStyle, isFocused, editorEngine.theme]);
 
         // Update color state when getColor changes

--- a/packages/utility/src/color.ts
+++ b/packages/utility/src/color.ts
@@ -337,3 +337,13 @@ function rgb2hsv({ r, g, b }: { r: number; g: number; b: number }): {
     const h = c && (v === r ? (g - b) / c : v === g ? 2 + (b - r) / c : 4 + (r - g) / c);
     return { h: (h < 0 ? h + 6 : h) / 6, s: v && c / v, v };
 }
+
+export function resolveCssVariables(
+    valueWithVars: string,
+    styleRecord: Record<string, string>,
+    fallback = '1',
+): string {
+    return valueWithVars.replace(/var\((--[^)]+)\)/g, (_, varName: string) => {
+        return styleRecord[varName] ?? fallback;
+    });
+}


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

This PR addresses an issue where the style panel failed to detect and display the applied text color on elements.

## Related Issues

Closes #1762

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `ColorInput` by resolving CSS variables to correctly detect applied text color.
> 
>   - **Behavior**:
>     - Fixes bug in `ColorInput` where applied text color was not detected due to unresolved CSS variables.
>     - Uses `resolveCssVariables` to resolve CSS variables in `ColorInput`.
>   - **Functions**:
>     - Adds `resolveCssVariables` to `color.ts` to replace CSS variables with actual values from `styleRecord`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 9d4b4ed7590244bea4a0ea47fddb998017f0e7b8. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->